### PR TITLE
Fixed ommited semicolon in output when no default value is defined for a property.

### DIFF
--- a/src/ClassTemplate/ClassProperty.php
+++ b/src/ClassTemplate/ClassProperty.php
@@ -19,9 +19,9 @@ class ClassProperty extends Statement
     {
         $code = $this->scope . ' $' . $this->name;
         if ( $this->value ) {
-            $code .= ' = ' . var_export($this->value,true) . ';';
+            $code .= ' = ' . var_export($this->value,true);
         }
-        return $code;
+        return $code . ';';
     }
 
 }


### PR DESCRIPTION
Title says it all, I guess :)
